### PR TITLE
Add german localization

### DIFF
--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1,0 +1,22 @@
+en:
+  js:
+    voting:
+      reached_limit: "Dir sind die Votes ausgegangen, entferne einen vorhandenen Vote!"
+      list_votes: "Deine Votes auflisten"
+      votes_nav_help: "Themen mit den meisten Votes"
+      voted: "Du hast für dieses Thema gevotet"
+      allow_topic_voting: "Benutzern erlauben, für Themen in dieser Kategorie zu voten"
+      vote_title: "Vote"
+      vote_title_plural: "Votes"
+      voted_title: "Voted"
+      voting_closed_title: "Geschlossen"
+      voting_limit: "Limit"
+      votes_left:
+        one: "Du hast 1 Vote übrig, siehe <a href='{{path}}'>deine Votes</a>."
+        other: "Dir bleiben {{count}} Votes, siehe <a href='{{path}}'>deine Votes</a>."
+      votes:
+        one: "1 Vote"
+        other: "{{count}} Votes"
+    filters:
+      votes:
+        title: "Votes"

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -1,0 +1,11 @@
+en:
+  site_settings:
+    voting_enabled: 'Benutzern erlauben, für Themen zu voten?'
+    voting_tl0_vote_limit: 'Wie viele aktive Votes sind TL0-Benutzern erlaubt?'
+    voting_tl1_vote_limit: 'Wie viele aktive Votes sind TL1-Benutzern erlaubt?'
+    voting_tl2_vote_limit: 'Wie viele aktive Votes sind TL2-Benutzern erlaubt?'
+    voting_tl3_vote_limit: 'Wie viele aktive Votes sind TL3-Benutzern erlaubt?'
+    voting_tl4_vote_limit: 'Wie viele aktive Votes sind TL4-Benutzern erlaubt?'
+    voting_show_who_voted: 'Benutzern erlauben, zu sehen, wer gevotet hat?'
+    voting_show_votes_on_profile: 'Benutzern erlauben, ihre Votes in ihrem Benutzerprofil einzusehen?'
+    voting_alert_votes-left: 'Benutzer benachrichten, wenn diese Anzahl von Votes verblieben sind'


### PR DESCRIPTION
I had to do a more colloquial, yet correct translation. Correct me if I'm wrong, but the reason is that in https://github.com/discourse/discourse-voting/blob/master/assets/javascripts/discourse/widgets/vote-button.js.es6#L32 and https://github.com/discourse/discourse-voting/blob/master/assets/javascripts/discourse/widgets/vote-button.js.es6#L49 the key `voting.vote_title` ("Vote") is used as a noun _and_ a verb. In German it's two different words: "Stimme" ("vote" as noun) and "Abstimmen" ("to vote"). As a workaround I used the more or less common Anglicism "Vote", which is also equally spelled as a noun and verb in German.

To make a long story short: The translation should suffice, but if im right with my notion, maybe this has to be changed in the future to provide a better translation.