### PR TITLE
Re-render "who voted" list when a vote is removed

### DIFF
--- a/assets/javascripts/discourse/widgets/vote-box.js.es6
+++ b/assets/javascripts/discourse/widgets/vote-box.js.es6
@@ -62,10 +62,10 @@ export default createWidget('vote-box', {
       this.currentUser.set('votes_exceeded', !result.can_vote);
       if (result.alert) {
         state.votesAlert = result.votes_left;
-        this.scheduleRerender();
       }
       topic.set('who_voted', result.who_voted);
       state.allowClick = true;
+      this.scheduleRerender();
     }).catch(popupAjaxError);
   },
 
@@ -83,6 +83,7 @@ export default createWidget('vote-box', {
       this.currentUser.set('votes_exceeded', !result.can_vote);
       topic.set('who_voted', result.who_voted);
       state.allowClick = true;
+      this.scheduleRerender();
     }).catch(popupAjaxError);
   }
 


### PR DESCRIPTION
Ensures that `this.scheduleRerender()` is always called when adding or removing a vote; this will ensure that the "who voted" list is updated. This fixes https://meta.discourse.org/t/avatar-still-shown-in-voted-pane-after-vote-removed/66480 .