### PR TITLE
FIX: release/relcaim votes when topic is closed, clear duplicate and null votes

### DIFF
--- a/app/controllers/discourse_voting/votes_controller.rb
+++ b/app/controllers/discourse_voting/votes_controller.rb
@@ -20,8 +20,8 @@ module DiscourseVoting
 
       unless current_user.reached_voting_limit?
 
-        current_user.custom_fields["votes"] = current_user.votes.dup.push(params["topic_id"])
-        current_user.save
+        current_user.custom_fields[DiscourseVoting::VOTES] = current_user.votes.dup.push(params["topic_id"]).uniq
+        current_user.save!
 
         topic.update_vote_count
 
@@ -31,7 +31,7 @@ module DiscourseVoting
       obj = {
         can_vote: !current_user.reached_voting_limit?,
         vote_limit: current_user.vote_limit,
-        vote_count: topic.custom_fields["vote_count"].to_i,
+        vote_count: topic.custom_fields[DiscourseVoting::VOTE_COUNT].to_i,
         who_voted: who_voted(topic),
         alert:  current_user.alert_low_votes?,
         votes_left: [(current_user.vote_limit - current_user.vote_count), 0].max
@@ -45,15 +45,15 @@ module DiscourseVoting
 
       guardian.ensure_can_see!(topic)
 
-      current_user.custom_fields["votes"] = current_user.votes.dup - [params["topic_id"].to_s]
-      current_user.save
+      current_user.custom_fields[DiscourseVoting::VOTES] = current_user.votes.dup - [params["topic_id"].to_s]
+      current_user.save!
 
       topic.update_vote_count
 
       obj = {
         can_vote: !current_user.reached_voting_limit?,
         vote_limit: current_user.vote_limit,
-        vote_count: topic.custom_fields["vote_count"].to_i,
+        vote_count: topic.custom_fields[DiscourseVoting::VOTE_COUNT].to_i,
         who_voted: who_voted(topic),
         votes_left: [(current_user.vote_limit - current_user.vote_count), 0].max
       }

--- a/app/jobs/onceoff/clean_dup_null_votes.rb
+++ b/app/jobs/onceoff/clean_dup_null_votes.rb
@@ -1,0 +1,60 @@
+module Jobs
+  class CleanDupNullVotes < Jobs::Onceoff
+    def execute_onceoff(args)
+      # delete duplicate votes
+      DB.exec("
+        DELETE FROM user_custom_fields ucf1
+        USING user_custom_fields ucf2
+        WHERE ucf1.id < ucf2.id AND
+              ucf1.user_id = ucf2.user_id AND
+              ucf1.value = ucf2.value AND
+              ucf1.name = ucf2.name AND
+              (ucf1.name IN ('#{DiscourseVoting::VOTES}', '#{DiscourseVoting::VOTES_ARCHIVE}'))
+      ")
+
+      # delete votes associated with no topics
+      DB.exec("
+        DELETE FROM user_custom_fields ucf
+        WHERE ucf.value IS NULL
+        AND ucf.name IN ('#{DiscourseVoting::VOTES}', '#{DiscourseVoting::VOTES_ARCHIVE}')
+      ")
+
+      # delete duplicate vote counts for topics
+      DB.exec("
+        DELETE FROM topic_custom_fields tcf
+        USING topic_custom_fields tcf2
+        WHERE tcf.id < tcf2.id AND
+              tcf.name = tcf2.name AND
+              tcf.topic_id = tcf2.topic_id AND
+              tcf.value = tcf.value AND
+              tcf.name = '#{DiscourseVoting::VOTE_COUNT}'
+      ")
+
+      # insert missing vote counts for topics
+      DB.exec("
+        WITH missing_ids AS (
+          SELECT t.id FROM topics t
+          JOIN user_custom_fields ucf
+          ON t.id::text = ucf.value
+          LEFT JOIN topic_custom_fields tcf
+          ON t.id = tcf.topic_id
+          WHERE ucf.name IN ('#{DiscourseVoting::VOTES}', '#{DiscourseVoting::VOTES_ARCHIVE}') AND
+          tcf.topic_id IS NULL OR tcf.name <> '#{DiscourseVoting::VOTE_COUNT}'
+        )
+        INSERT INTO topic_custom_fields (value, topic_id, name, created_at, updated_at)
+        SELECT '0', id, '#{DiscourseVoting::VOTE_COUNT}', now(), now() FROM missing_ids
+      ")
+
+      # correct topics vote counts
+      DB.exec("
+        UPDATE topic_custom_fields tcf
+        SET value = (
+          SELECT COUNT(*) FROM user_custom_fields ucf
+          WHERE tcf.topic_id::text = ucf.value AND ucf.name IN ('#{DiscourseVoting::VOTES}', '#{DiscourseVoting::VOTES_ARCHIVE}')
+          GROUP BY ucf.value
+        )
+        WHERE tcf.name = '#{DiscourseVoting::VOTE_COUNT}'
+      ")
+    end
+  end
+end

--- a/spec/requests/votes_controller_spec.rb
+++ b/spec/requests/votes_controller_spec.rb
@@ -26,7 +26,7 @@ describe DiscourseVoting::VotesController do
 
   context "when a user has tallyed votes with no topic id" do
     before do
-      user.custom_fields["votes"] = [nil, nil, nil]
+      user.custom_fields[DiscourseVoting::VOTES] = [nil, nil, nil]
       user.save
     end
 

--- a/spec/voting_spec.rb
+++ b/spec/voting_spec.rb
@@ -18,6 +18,18 @@ describe DiscourseVoting do
     SiteSetting.voting_show_who_voted = true
   end
 
+  it "doesn't allow users to vote more than they are allowed" do
+    SiteSetting.voting_tl1_vote_limit = 1
+    user0.update!(trust_level: 1)
+
+    expect(user0.reached_voting_limit?).to eq(false)
+
+    user0.custom_fields["votes"] = [topic0.id.to_s]
+    user0.save!
+
+    expect(user0.reached_voting_limit?).to eq(true)
+  end
+
   it 'moves votes when topics are merged' do
     users = [user0, user1, user2, user3]
 


### PR DESCRIPTION
* Fixes a bug where the job for releasing/reclaiming votes wasn't enqueued when topic is closed (reported [here](https://meta.discourse.org/t/votes-not-being-released-after-close/96394?u=osama))

* Somehow a user may have duplicate votes to the same topic and all of the dup votes count towards their quota. This will ignore duplicate votes.

* Topic vote counter didn't count archived votes.

* Moving a topic to a different category didn't release/reclaim votes correctly, this PR fixes that.

* Get rid of vote records with `nil` topic_id

* Adds a onceoff job to clean up mess.