### PR TITLE
FIX: Use correct URL for sorting by votes.

### DIFF
--- a/assets/javascripts/discourse/pre-initializers/extend-category-for-voting.js.es6
+++ b/assets/javascripts/discourse/pre-initializers/extend-category-for-voting.js.es6
@@ -50,11 +50,6 @@ export default {
     });
 
     Category.reopen({
-      @computed("url")
-      votesUrl(url) {
-        return `${url}/l/votes`;
-      },
-
       @computed("custom_fields.enable_topic_voting")
       enable_topic_voting: {
         get(enableField) {

--- a/assets/javascripts/discourse/templates/connectors/extra-nav-item/votes.hbs
+++ b/assets/javascripts/discourse/templates/connectors/extra-nav-item/votes.hbs
@@ -1,3 +1,3 @@
 {{#if siteSettings.voting_enabled}}
-<a title="{{I18n "voting.votes_nav_help"}}" href="{{category.votesUrl}}">{{I18n "voting.vote_title_plural"}}</a>
+<a title="{{I18n "voting.votes_nav_help"}}" href="{{url}}">{{I18n "voting.vote_title_plural"}}</a>
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/extra-nav-item/votes.js.es6
+++ b/assets/javascripts/discourse/templates/connectors/extra-nav-item/votes.js.es6
@@ -1,24 +1,9 @@
 export default {
-  votedPath() {
-    return "foobar";
-  },
-  path(category) {
-    if (category) {
-      return category.get("votesUrl");
-    }
-  },
-  displayName() {
-    return I18n.t("voting.vote_title_plural");
-  },
   setupComponent(args, component) {
-    const filterMode = args.filterMode;
-    // no endsWith in IE
-    if (
-      filterMode &&
-      filterMode.indexOf("votes", filterMode.length - 5) !== -1
-    ) {
-      component.set("classNames", ["active"]);
-    }
+    component.set(
+      "url",
+      Discourse.BaseUri + "/" + args.filterMode + "?order=votes"
+    );
   },
   shouldRender(args, component) {
     const category = component.get("category");


### PR DESCRIPTION
It used to be a link using the "votes" filter mode which was overwritten
by default category sort order.

Instead, one should use the 'order' query parameter to sort the topic
list by number of votes.

This commit also removes some dead code.