### PR TITLE
 FEATURE: Let user know how many votes were moved.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,3 +9,10 @@ en:
     voting_show_who_voted: 'Allow users to see who voted?'
     voting_show_votes_on_profile: 'Allow users to see their votes in their activity feed?'
     voting_alert_votes_left: 'Alert user when this many votes are left'
+  voting:
+    votes_moved:
+      one: "A vote has been moved."
+      other: "%{count} votes have been moved."
+    duplicated_votes:
+      one: "A vote could not be moved because the user already voted in the other topic."
+      other: "%{count} votes could not be moved because their users already voted in the other topic."

--- a/spec/ensure_consistency_spec.rb
+++ b/spec/ensure_consistency_spec.rb
@@ -2,9 +2,8 @@
 
 require 'rails_helper'
 
-describe "Voting Consistency" do
-  it "cleans up mess" do
-
+describe Jobs::VotingEnsureConsistency do
+  it "ensures consistency" do
     user = Fabricate(:user)
     user2 = Fabricate(:user)
 
@@ -29,16 +28,13 @@ describe "Voting Consistency" do
     UserCustomField.create!(user_id: user.id, name: DiscourseVoting::VOTES_ARCHIVE, value: two_vote_topic.id)
     UserCustomField.create!(user_id: user2.id, name: DiscourseVoting::VOTES, value: two_vote_topic.id)
 
-    Jobs::VotingEnsureConsistency.new.execute_onceoff(nil)
+    subject.execute_onceoff(nil)
 
     no_vote_topic.reload
     expect(no_vote_topic.custom_fields["random1"]).to eq("random")
 
-    user.reload
-    expect(user.custom_fields).to eq("votes" => [one_vote_topic.id, two_vote_topic.id])
-
-    user2.reload
-    expect(user2.custom_fields).to eq("votes" => [two_vote_topic.id])
+    expect(user.reload.custom_fields).to eq("votes" => [one_vote_topic.id, two_vote_topic.id])
+    expect(user2.reload.custom_fields).to eq("votes" => [two_vote_topic.id])
 
     one_vote_topic.reload
     expect(one_vote_topic.custom_fields["vote_count"]).to eq(1)
@@ -48,5 +44,8 @@ describe "Voting Consistency" do
     expect(two_vote_topic.custom_fields["vote_count"]).to eq(2)
     expect(two_vote_topic.custom_fields["random3"]).to eq("random")
 
+    expect(no_vote_topic.reload.custom_fields).to eq("random1" => "random")
+    expect(one_vote_topic.reload.custom_fields).to eq("vote_count" => 1, "random2" => "random")
+    expect(two_vote_topic.reload.custom_fields).to eq("vote_count" => 2, "random3" => "random")
   end
 end


### PR DESCRIPTION
Merging two votes with topics will edit the moderator post describing
the move operation, to include information about how many votes were
moved and why some votes were not (because user already voted for the
destination topic).

Example:

<img width="899" alt="Screen Shot 2019-08-11 at 20 29 48" src="https://user-images.githubusercontent.com/4147664/62837498-c80e7980-bc78-11e9-9817-76cae7f79411.png">
