### PR TITLE
REFACTOR: plugin CSS cleanup

### DIFF
--- a/assets/stylesheets/common/feature-voting.scss
+++ b/assets/stylesheets/common/feature-voting.scss
@@ -1,80 +1,102 @@
-.voting {
-  min-width: 70px;
-  float: left;
-  text-align: center;
-  margin-right: 20px;
+.title-voting {
+  padding-right: 0.75em;
+  width: 6em;
   max-width: 10%;
+  box-sizing: border-box;
+  float: left;
 }
+
 .vote-count-wrapper {
   border: 3px solid $primary-low;
 }
+
 .voting-wrapper.show-pointer .vote-count-wrapper:not(.no-votes) {
   cursor: pointer;
   &:hover {
     background-color: $primary-low;
   }
 }
-.vote-count {
+
+.vote-count-wrapper {
   font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
+
 .title-voting {
+  // matches core title-wrapper padding
   padding-top: 14px;
   position: relative;
 }
+
 .vote-button {
   width: 100%;
-  margin-top: 5px;
+  margin-top: 0.35em;
 }
+
 .vote-options {
   text-align: left;
 }
+
 .vote-option {
   cursor: pointer;
-  padding: 5px;
+  padding: 0.35em;
   &:hover {
     background-color: $primary-low;
   }
 }
+
 .vote-option.remove-vote .d-icon {
-  margin-right: 6px;
+  margin-right: 0.35em;
   color: $danger;
 }
-.vote-option-description {
-  font-size: $font-down-1;
-  margin-left: 18px;
-}
+
 .list-vote-count.voted {
   font-weight: bold;
 }
+
 .who-voted.popup-menu {
   a {
-    margin: 0.4em 0.25em 0.4em 0;
+    margin: 0.4em 0.25em;
     display: inline-block;
   }
 }
-.upgrade-vote {
-  text-align: center;
-}
-.upgrade-vote .vote-option-description {
-  margin-left: 0;
-}
-.upgrade-answer {
-  text-decoration: underline;
-  font-weight: bold;
-  i {
-    margin: 0px 5px 0px 0px;
-  }
-}
+
 .topic-post.voting-post {
   button.like-count,
   button.toggle-like {
     display: none;
   }
 }
+
 .voting-popup-menu {
   position: absolute;
   left: 80px;
+  // matches core title-wrapper padding
   top: 14px;
-  z-index: z("header") - 1;
+  z-index: z("usercard") - 1;
   cursor: initial;
+  // voter avatars
+  .regular-votes {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+// TEMP: RTL overrides
+.title-voting {
+  .rtl & {
+    float: right;
+    padding-right: 0;
+    padding-left: 0.75em;
+  }
+}
+
+.voting-popup-menu {
+  .rtl & {
+    left: unset;
+    right: 80px;
+  }
 }

--- a/assets/stylesheets/desktop/feature-voting.scss
+++ b/assets/stylesheets/desktop/feature-voting.scss
@@ -1,7 +1,4 @@
-.vote-count {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.vote-count-wrapper {
   font-size: $font-up-2;
   height: 40px;
 }

--- a/assets/stylesheets/mobile/feature-voting.scss
+++ b/assets/stylesheets/mobile/feature-voting.scss
@@ -1,4 +1,5 @@
-.voting {
+.title-voting {
+  width: 100%;
   float: none;
   max-width: none;
   text-align: inherit;
@@ -11,10 +12,28 @@
 
 .vote-count-wrapper {
   min-width: 70px;
-  text-align: center;
+  box-sizing: border-box;
+  // match button height
+  min-height: 30px;
 }
 
 .vote-button {
-  margin-left: 5px;
+  max-width: 10em;
+  margin-left: 0.5em;
   margin-top: 0;
+  white-space: nowrap;
+}
+
+// TEMP: RTL overrides
+.title-voting {
+  .rtl & {
+    float: none;
+  }
+}
+
+.vote-button {
+  .rtl & {
+    margin-left: 0;
+    margin-right: 0.5em;
+  }
 }


### PR DESCRIPTION
This PR refactors the plugin's CSS.

Notable changes:

1. changes most `px` units to `em` units (the ones left as `px` have good reasons to be)
2. uses flexbox for improved alignment
3. removes some unused styles (super votes)
4. improves support for RTL locales (this is TEMP see https://meta.discourse.org/t/moving-the-voting-box-to-the-right-side-of-the-screen/126752 for more details. I added these to the very bottom for easy removal in the future once the main cause is fixed.
5. minor fixes like preventing the pop-up menu from overlapping with user-cards

Before (LTR - desktop)

<img src="https://user-images.githubusercontent.com/33972521/63753234-4740b600-c8e5-11e9-8d43-b97f9ef4ef06.png" width="500">

After (LTR -  desktop)

<img src="https://user-images.githubusercontent.com/33972521/63752970-c2559c80-c8e4-11e9-8010-e2230d22be63.png" width="500">

Before (RTL - desktop) 

<img src="https://user-images.githubusercontent.com/33972521/63753290-5aec1c80-c8e5-11e9-8016-ccffc14ccd62.png" width="500">

After (RTL - desktop)

<img src="https://user-images.githubusercontent.com/33972521/63752922-ab16af00-c8e4-11e9-80cf-c8e8542e0d5a.png" width="500">

Before (LTR - mobile)


<img src="https://user-images.githubusercontent.com/33972521/63753347-7b1bdb80-c8e5-11e9-9aa2-0a0117fd9c73.png" width="300">

After (LTR - mobile) 

<img src="https://user-images.githubusercontent.com/33972521/63752429-cd5bfd00-c8e3-11e9-84c6-1b5ce7a86157.png" width="300">

Before (RTL - mobile)

<img src="https://user-images.githubusercontent.com/33972521/63753323-6d665600-c8e5-11e9-9596-00dce70bf0c9.png" width="300">

After (RTL - mobile)

<img src="https://user-images.githubusercontent.com/33972521/63752520-f9777e00-c8e3-11e9-8d02-f13addaed73c.png" width="300">

Before (user-card overlap)

<img src="https://user-images.githubusercontent.com/33972521/63753530-d5b53780-c8e5-11e9-8040-0fcf6d05fad6.png" width="400">

After (user-card overlap)

<img src="https://user-images.githubusercontent.com/33972521/63753580-ea91cb00-c8e5-11e9-9b0d-f26ebc110c62.png" width="400">

The CSS still uses `float` to position the voting area next to the title, which not ideal. I wanted to get rid of that but the current implementation / layout still requires it. Hopefully I'll be able to revisit in the future and fix that.  