### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/onceoff/voting_ensure_consistency.rb
+++ b/app/jobs/onceoff/voting_ensure_consistency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class VotingEnsureConsistency < Jobs::Onceoff
+  class VotingEnsureConsistency < ::Jobs::Onceoff
     def execute_onceoff(args)
       aliases = {
         vote_count: DiscourseVoting::VOTE_COUNT,

--- a/plugin.rb
+++ b/plugin.rb
@@ -290,7 +290,7 @@ after_initialize do
   require_dependency "jobs/base"
   module ::Jobs
 
-    class VoteRelease < Jobs::Base
+    class VoteRelease < ::Jobs::Base
       def execute(args)
         if topic = Topic.find_by(id: args[:topic_id])
           UserCustomField.where(name: DiscourseVoting::VOTES, value: args[:topic_id]).find_each do |user_field|
@@ -304,7 +304,7 @@ after_initialize do
       end
     end
 
-    class VoteReclaim < Jobs::Base
+    class VoteReclaim < ::Jobs::Base
       def execute(args)
         if topic = Topic.find_by(id: args[:topic_id])
           UserCustomField.where(name: DiscourseVoting::VOTES_ARCHIVE, value: topic.id).find_each do |user_field|


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364