### PR TITLE
FIX: user vote count is updated when topics are trashed/restored

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -292,7 +292,7 @@ after_initialize do
 
     class VoteRelease < ::Jobs::Base
       def execute(args)
-        if topic = Topic.find_by(id: args[:topic_id])
+        if topic = Topic.with_deleted.find_by(id: args[:topic_id])
           UserCustomField.where(name: DiscourseVoting::VOTES, value: args[:topic_id]).find_each do |user_field|
             user = User.find(user_field.user_id)
             user.custom_fields[DiscourseVoting::VOTES] = user.votes.dup - [args[:topic_id]]

--- a/plugin.rb
+++ b/plugin.rb
@@ -330,6 +330,14 @@ after_initialize do
     end
   end
 
+  DiscourseEvent.on(:topic_trashed) do |topic|
+		Jobs.enqueue(:vote_release, topic_id: topic.id) if !topic.closed && !topic.archived
+	end
+
+	DiscourseEvent.on(:topic_recovered) do |topic|
+		Jobs.enqueue(:vote_reclaim, topic_id: topic.id) if !topic.closed && !topic.archived
+  end
+
   DiscourseEvent.on(:post_edited) do |post, topic_changed|
     if topic_changed &&
         SiteSetting.voting_enabled &&

--- a/plugin.rb
+++ b/plugin.rb
@@ -306,7 +306,7 @@ after_initialize do
 
     class VoteReclaim < ::Jobs::Base
       def execute(args)
-        if topic = Topic.find_by(id: args[:topic_id])
+        if topic = Topic.with_deleted.find_by(id: args[:topic_id])
           UserCustomField.where(name: DiscourseVoting::VOTES_ARCHIVE, value: topic.id).find_each do |user_field|
             user = User.find(user_field.user_id)
             user.custom_fields[DiscourseVoting::VOTES] = user.votes.dup.push(topic.id).uniq

--- a/plugin.rb
+++ b/plugin.rb
@@ -331,11 +331,11 @@ after_initialize do
   end
 
   DiscourseEvent.on(:topic_trashed) do |topic|
-		Jobs.enqueue(:vote_release, topic_id: topic.id) if !topic.closed && !topic.archived
-	end
+    Jobs.enqueue(:vote_release, topic_id: topic.id) if !topic.closed && !topic.archived
+  end
 
-	DiscourseEvent.on(:topic_recovered) do |topic|
-		Jobs.enqueue(:vote_reclaim, topic_id: topic.id) if !topic.closed && !topic.archived
+  DiscourseEvent.on(:topic_recovered) do |topic|
+    Jobs.enqueue(:vote_reclaim, topic_id: topic.id) if !topic.closed && !topic.archived
   end
 
   DiscourseEvent.on(:post_edited) do |post, topic_changed|

--- a/spec/voting_spec.rb
+++ b/spec/voting_spec.rb
@@ -110,19 +110,14 @@ describe DiscourseVoting do
 
   context "when a job is trashed and then recovered" do
     it "released the vote back to the user, then reclaims it on topic recovery" do
+      Jobs.run_immediately!
       user0.custom_fields[DiscourseVoting::VOTES] = [topic1.id]
       user0.save
 
-      topic1.trash!
-      expect(Jobs::VoteRelease.jobs.first["args"].first["topic_id"]).to eq(topic1.id)
-      Jobs::VoteRelease.new.execute(topic_id: topic1.id)
-
+      topic1.reload.trash!
       expect(user0.reload.votes).to eq([])
 
       topic1.recover!
-      expect(Jobs::VoteReclaim.jobs.first["args"].first["topic_id"]).to eq(topic1.id)
-      Jobs::VoteReclaim.new.execute(topic_id: topic1.id)
-
       expect(user0.reload.votes).to eq([topic1.id])
     end
   end

--- a/spec/voting_spec.rb
+++ b/spec/voting_spec.rb
@@ -109,8 +109,6 @@ describe DiscourseVoting do
   end
 
   context "when topic is trashed" do
-		let (:user) { Fabricate(:user) }
-
     it "enqueues a job for releasing votes" do
       DiscourseEvent.on(:topic_trashed) do |topic|
         expect(topic).to be_instance_of(Topic)


### PR DESCRIPTION
Addressing [this thread](https://meta.discourse.org/t/deleteing-a-topic-with-votes-not-releasing-votes/130009/7)

The specs looks short, but all we really need to test is whether or not the `VoteReclaim` and `VoteRelease` jobs are run, because they are tested and bear the responsibility of updating the user count properly.

[Supporting PR](https://github.com/discourse/discourse/pull/8144) for discourse main app