### PR TITLE
FIX: include all reloadable parts of the plugin

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -70,75 +70,74 @@ after_initialize do
         end
       end
     end
-  end
 
-  add_to_serializer(:topic_list_item, :vote_count) { object.vote_count }
-  add_to_serializer(:topic_list_item, :can_vote) { object.can_vote? }
-  add_to_serializer(:topic_list_item, :user_voted) {
-    object.user_voted(scope.user) if scope.user
-  }
+    add_to_serializer(:topic_list_item, :vote_count) { object.vote_count }
+    add_to_serializer(:topic_list_item, :can_vote) { object.can_vote? }
+    add_to_serializer(:topic_list_item, :user_voted) {
+      object.user_voted(scope.user) if scope.user
+    }
 
-  add_to_serializer(:basic_category, :can_vote, false) do
-    SiteSetting.voting_enabled
-  end
-
-  add_to_serializer(:basic_category, :include_can_vote?) do
-    Category.can_vote?(object.id)
-  end
-
-  class ::Category
-    def self.reset_voting_cache
-      @allowed_voting_cache["allowed"] =
-        begin
-          Set.new(
-            CategoryCustomField
-            .where(name: ::DiscourseVoting::VOTING_ENABLED, value: "true")
-            .pluck(:category_id)
-          )
-        end
+    add_to_serializer(:basic_category, :can_vote, false) do
+      SiteSetting.voting_enabled
     end
 
-    @allowed_voting_cache = DistributedCache.new("allowed_voting")
+    add_to_serializer(:basic_category, :include_can_vote?) do
+      Category.can_vote?(object.id)
+    end
 
-    def self.can_vote?(category_id)
-      return false unless SiteSetting.voting_enabled
-
-      unless set = @allowed_voting_cache["allowed"]
-        set = reset_voting_cache
+    class ::Category
+      def self.reset_voting_cache
+        @allowed_voting_cache["allowed"] =
+          begin
+            Set.new(
+              CategoryCustomField
+              .where(name: ::DiscourseVoting::VOTING_ENABLED, value: "true")
+              .pluck(:category_id)
+            )
+          end
       end
-      set.include?(category_id)
-    end
 
-    after_save :reset_voting_cache
-    before_save :reclaim_release_votes
+      @allowed_voting_cache = DistributedCache.new("allowed_voting")
 
-    protected
-    def reset_voting_cache
-      ::Category.reset_voting_cache
-    end
+      def self.can_vote?(category_id)
+        return false unless SiteSetting.voting_enabled
 
-    def reclaim_release_votes
-      return if self.new_record?
-      return if !SiteSetting.voting_enabled
+        unless set = @allowed_voting_cache["allowed"]
+          set = reset_voting_cache
+        end
+        set.include?(category_id)
+      end
 
-      aliases = {
-        votes: DiscourseVoting::VOTES,
-        votes_archive: DiscourseVoting::VOTES_ARCHIVE,
-        category_id: id
-      }
+      after_save :reset_voting_cache
+      before_save :reclaim_release_votes
 
-      was_enabled = CategoryCustomField.where(
-        "name = :name AND value similar to :value AND category_id = :id",
-        id: id,
-        name: ::DiscourseVoting::VOTING_ENABLED,
-        value: '(t|T|1)%'
-      ).exists?
+      protected
+      def reset_voting_cache
+        ::Category.reset_voting_cache
+      end
 
-      is_enabled = custom_fields[::DiscourseVoting::VOTING_ENABLED]
+      def reclaim_release_votes
+        return if self.new_record?
+        return if !SiteSetting.voting_enabled
 
-      if !was_enabled && is_enabled
-        # Unarchive all votes in the category
-        DB.exec(<<~SQL, aliases)
+        aliases = {
+          votes: DiscourseVoting::VOTES,
+          votes_archive: DiscourseVoting::VOTES_ARCHIVE,
+          category_id: id
+        }
+
+        was_enabled = CategoryCustomField.where(
+          "name = :name AND value similar to :value AND category_id = :id",
+          id: id,
+          name: ::DiscourseVoting::VOTING_ENABLED,
+          value: '(t|T|1)%'
+        ).exists?
+
+        is_enabled = custom_fields[::DiscourseVoting::VOTING_ENABLED]
+
+        if !was_enabled && is_enabled
+          # Unarchive all votes in the category
+          DB.exec(<<~SQL, aliases)
           UPDATE user_custom_fields ucf
           SET name = :votes
           FROM topics t
@@ -148,176 +147,177 @@ after_initialize do
           AND t.deleted_at IS NULL
           AND t.id::text = ucf.value
           AND t.category_id = :category_id
-        SQL
-      elsif was_enabled && !is_enabled
-        # Archive all votes in category
-        DB.exec(<<~SQL, aliases)
+          SQL
+        elsif was_enabled && !is_enabled
+          # Archive all votes in category
+          DB.exec(<<~SQL, aliases)
           UPDATE user_custom_fields ucf
           SET name = :votes_archive
           FROM topics t
           WHERE ucf.name = :votes
           AND t.id::text = ucf.value
           AND t.category_id = :category_id
-        SQL
-      end
-    end
-  end
-
-  require_dependency 'user'
-  class ::User
-    def vote_count
-      votes.length
-    end
-
-    def alert_low_votes?
-      (vote_limit - vote_count) <= SiteSetting.voting_alert_votes_left
-    end
-
-    def votes
-      votes = self.custom_fields[DiscourseVoting::VOTES] || []
-      # "" can be in there sometimes, it gets turned into a 0
-      votes = votes.reject { |v| v == 0 }.uniq
-      votes
-    end
-
-    def votes_archive
-      archived_votes = self.custom_fields[DiscourseVoting::VOTES_ARCHIVE] || []
-      archived_votes = archived_votes.reject { |v| v == 0 }.uniq
-      archived_votes
-    end
-
-    def reached_voting_limit?
-      vote_count >= vote_limit
-    end
-
-    def vote_limit
-      SiteSetting.public_send("voting_tl#{self.trust_level}_vote_limit")
-    end
-
-  end
-
-  require_dependency 'current_user_serializer'
-  class ::CurrentUserSerializer
-    attributes :votes_exceeded,  :vote_count
-
-    def votes_exceeded
-      object.reached_voting_limit?
-    end
-
-    def vote_count
-      object.vote_count
-    end
-
-  end
-
-  require_dependency 'topic'
-  class ::Topic
-
-    def can_vote?
-      SiteSetting.voting_enabled && Category.can_vote?(category_id) && category.topic_id != id
-    end
-
-    def vote_count
-      if count = self.custom_fields[DiscourseVoting::VOTE_COUNT]
-        # we may have a weird array here, don't explode
-        # need to fix core to enforce types on fields
-        count.try(:to_i) || 0
-      else
-        0 if self.can_vote?
+          SQL
+        end
       end
     end
 
-    def user_voted(user)
-      if user && user.custom_fields[DiscourseVoting::VOTES]
-        user.custom_fields[DiscourseVoting::VOTES].include? self.id
-      else
-        false
+    require_dependency 'user'
+    class ::User
+      def vote_count
+        votes.length
       end
+
+      def alert_low_votes?
+        (vote_limit - vote_count) <= SiteSetting.voting_alert_votes_left
+      end
+
+      def votes
+        votes = self.custom_fields[DiscourseVoting::VOTES] || []
+        # "" can be in there sometimes, it gets turned into a 0
+        votes = votes.reject { |v| v == 0 }.uniq
+        votes
+      end
+
+      def votes_archive
+        archived_votes = self.custom_fields[DiscourseVoting::VOTES_ARCHIVE] || []
+        archived_votes = archived_votes.reject { |v| v == 0 }.uniq
+        archived_votes
+      end
+
+      def reached_voting_limit?
+        vote_count >= vote_limit
+      end
+
+      def vote_limit
+        SiteSetting.public_send("voting_tl#{self.trust_level}_vote_limit")
+      end
+
     end
 
-    def update_vote_count
-      count =
-        UserCustomField.where("value = :value AND name IN (:keys)",
-          value: id.to_s, keys: [DiscourseVoting::VOTES, DiscourseVoting::VOTES_ARCHIVE]).count
+    require_dependency 'current_user_serializer'
+    class ::CurrentUserSerializer
+      attributes :votes_exceeded,  :vote_count
 
-      custom_fields[DiscourseVoting::VOTE_COUNT] = count
-      save_custom_fields
+      def votes_exceeded
+        object.reached_voting_limit?
+      end
+
+      def vote_count
+        object.vote_count
+      end
+
     end
 
-    def who_voted
-      return nil unless SiteSetting.voting_show_who_voted
+    require_dependency 'topic'
+    class ::Topic
 
-      User.where("id in (
+      def can_vote?
+        SiteSetting.voting_enabled && Category.can_vote?(category_id) && category.topic_id != id
+      end
+
+      def vote_count
+        if count = self.custom_fields[DiscourseVoting::VOTE_COUNT]
+          # we may have a weird array here, don't explode
+          # need to fix core to enforce types on fields
+          count.try(:to_i) || 0
+        else
+          0 if self.can_vote?
+        end
+      end
+
+      def user_voted(user)
+        if user && user.custom_fields[DiscourseVoting::VOTES]
+          user.custom_fields[DiscourseVoting::VOTES].include? self.id
+        else
+          false
+        end
+      end
+
+      def update_vote_count
+        count =
+          UserCustomField.where("value = :value AND name IN (:keys)",
+                                value: id.to_s, keys: [DiscourseVoting::VOTES, DiscourseVoting::VOTES_ARCHIVE]).count
+
+        custom_fields[DiscourseVoting::VOTE_COUNT] = count
+        save_custom_fields
+      end
+
+      def who_voted
+        return nil unless SiteSetting.voting_show_who_voted
+
+        User.where("id in (
         SELECT user_id FROM user_custom_fields WHERE name IN (:keys) AND value = :value
       )", value: id.to_s, keys: [DiscourseVoting::VOTES, DiscourseVoting::VOTES_ARCHIVE])
-    end
-
-  end
-
-  require_dependency 'list_controller'
-  class ::ListController
-    def voted_by
-      unless SiteSetting.voting_show_votes_on_profile
-        render nothing: true, status: 404
       end
-      list_opts = build_topic_list_options
-      target_user = fetch_user_from_params(include_inactive: current_user.try(:staff?))
-      list = generate_list_for("voted_by", target_user, list_opts)
-      list.more_topics_url = url_for(construct_url_with(:next, list_opts))
-      list.prev_topics_url = url_for(construct_url_with(:prev, list_opts))
-      respond_with_list(list)
+
     end
-  end
 
-  require_dependency 'topic_query'
-  class ::TopicQuery
-    SORTABLE_MAPPING["votes"] = "custom_fields.#{::DiscourseVoting::VOTE_COUNT}"
-
-    def list_voted_by(user)
-      create_list(:user_topics) do |topics|
-        topics.where(id: user.custom_fields[DiscourseVoting::VOTES])
+    require_dependency 'list_controller'
+    class ::ListController
+      def voted_by
+        unless SiteSetting.voting_show_votes_on_profile
+          render nothing: true, status: 404
+        end
+        list_opts = build_topic_list_options
+        target_user = fetch_user_from_params(include_inactive: current_user.try(:staff?))
+        list = generate_list_for("voted_by", target_user, list_opts)
+        list.more_topics_url = url_for(construct_url_with(:next, list_opts))
+        list.prev_topics_url = url_for(construct_url_with(:prev, list_opts))
+        respond_with_list(list)
       end
     end
 
-    def list_votes
-      create_list(:votes, unordered: true) do |topics|
-        topics.joins("left join topic_custom_fields tfv ON tfv.topic_id = topics.id AND tfv.name = '#{DiscourseVoting::VOTE_COUNT}'")
-          .order("coalesce(tfv.value,'0')::integer desc, topics.bumped_at desc")
+    require_dependency 'topic_query'
+    class ::TopicQuery
+      SORTABLE_MAPPING["votes"] = "custom_fields.#{::DiscourseVoting::VOTE_COUNT}"
+
+      def list_voted_by(user)
+        create_list(:user_topics) do |topics|
+          topics.where(id: user.custom_fields[DiscourseVoting::VOTES])
+        end
       end
-    end
-  end
 
-  require_dependency "jobs/base"
-  module ::Jobs
-
-    class VoteRelease < ::Jobs::Base
-      def execute(args)
-        if topic = Topic.with_deleted.find_by(id: args[:topic_id])
-          UserCustomField.where(name: DiscourseVoting::VOTES, value: args[:topic_id]).find_each do |user_field|
-            user = User.find(user_field.user_id)
-            user.custom_fields[DiscourseVoting::VOTES] = user.votes.dup - [args[:topic_id]]
-            user.custom_fields[DiscourseVoting::VOTES_ARCHIVE] = user.votes_archive.dup.push(args[:topic_id]).uniq
-            user.save!
-          end
-          topic.update_vote_count
+      def list_votes
+        create_list(:votes, unordered: true) do |topics|
+          topics.joins("left join topic_custom_fields tfv ON tfv.topic_id = topics.id AND tfv.name = '#{DiscourseVoting::VOTE_COUNT}'")
+            .order("coalesce(tfv.value,'0')::integer desc, topics.bumped_at desc")
         end
       end
     end
 
-    class VoteReclaim < ::Jobs::Base
-      def execute(args)
-        if topic = Topic.with_deleted.find_by(id: args[:topic_id])
-          UserCustomField.where(name: DiscourseVoting::VOTES_ARCHIVE, value: topic.id).find_each do |user_field|
-            user = User.find(user_field.user_id)
-            user.custom_fields[DiscourseVoting::VOTES] = user.votes.dup.push(topic.id).uniq
-            user.custom_fields[DiscourseVoting::VOTES_ARCHIVE] = user.votes_archive.dup - [topic.id]
-            user.save!
+    require_dependency "jobs/base"
+    module ::Jobs
+
+      class VoteRelease < ::Jobs::Base
+        def execute(args)
+          if topic = Topic.with_deleted.find_by(id: args[:topic_id])
+            UserCustomField.where(name: DiscourseVoting::VOTES, value: args[:topic_id]).find_each do |user_field|
+              user = User.find(user_field.user_id)
+              user.custom_fields[DiscourseVoting::VOTES] = user.votes.dup - [args[:topic_id]]
+              user.custom_fields[DiscourseVoting::VOTES_ARCHIVE] = user.votes_archive.dup.push(args[:topic_id]).uniq
+              user.save!
+            end
+            topic.update_vote_count
           end
-          topic.update_vote_count
         end
       end
-    end
 
+      class VoteReclaim < ::Jobs::Base
+        def execute(args)
+          if topic = Topic.with_deleted.find_by(id: args[:topic_id])
+            UserCustomField.where(name: DiscourseVoting::VOTES_ARCHIVE, value: topic.id).find_each do |user_field|
+              user = User.find(user_field.user_id)
+              user.custom_fields[DiscourseVoting::VOTES] = user.votes.dup.push(topic.id).uniq
+              user.custom_fields[DiscourseVoting::VOTES_ARCHIVE] = user.votes_archive.dup - [topic.id]
+              user.save!
+            end
+            topic.update_vote_count
+          end
+        end
+      end
+
+    end
   end
 
   DiscourseEvent.on(:topic_status_updated) do |topic, status, enabled|


### PR DESCRIPTION
Currently, if you got that plugin installed and change code in development in Discourse, you will see an error like:
`undefined method `can_vote?'`

A reason for that was incorrectly defined `reloadable_patch` block. That block defines everything which should be reloaded by ActiveSupport::Reloader if code is changed.

because that was not included in that block
```
class ::Category
  def self.can_vote?(category_id)
  end
end
```
method `can_vote?` was not anymore available.