### PR TITLE
FIX: the ability to remove the vote

### DIFF
--- a/assets/javascripts/discourse/widgets/vote-button.js.es6
+++ b/assets/javascripts/discourse/widgets/vote-button.js.es6
@@ -84,12 +84,12 @@ export default createWidget("vote-button", {
       this.sendWidgetAction("addVote");
     }
     if (this.attrs.user_voted || this.currentUser.votes_exceeded) {
-      $(".vote-options").toggle();
+      $(".vote-options").toggleClass("hidden");
     }
   },
 
   clickOutside() {
-    $(".vote-options").hide();
+    $(".vote-options").addClass("hidden");
     this.parentWidget.state.initialVote = false;
   },
 });


### PR DESCRIPTION
Problem was that we are adding `hidden` class to popup and jQuery `toggle()` function is not handling that properly. Therefore I decided to use `toggleClass` in that case and it works pretty well.

The bug was mentioned here - https://meta.discourse.org/t/voting-plugin/157676/8

![YFqWdYFAQd](https://user-images.githubusercontent.com/72780/93151569-a915cd00-f73f-11ea-9080-7ad542066a6a.gif)
