### PR TITLE
FIX: Stop trying to merge duplicate votes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+source 'https://rubygems.org'
+
 group :development do
   gem 'rubocop-discourse'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     jaro_winkler (1.5.4)

--- a/plugin.rb
+++ b/plugin.rb
@@ -309,8 +309,7 @@ after_initialize do
             duplicated_votes += 1
             user.votes.destroy_by(topic_id: orig.id)
           else
-            archived = dest.closed ? true : false
-            user.votes.find_by(topic_id: orig.id, user_id: user.id).update!(topic_id: dest.id, archive: archived)
+            user.votes.find_by(topic_id: orig.id, user_id: user.id).update!(topic_id: dest.id, archive: dest.closed)
             moved_votes += 1
           end
         else

--- a/spec/voting_spec.rb
+++ b/spec/voting_spec.rb
@@ -58,22 +58,22 @@ describe DiscourseVoting do
 
       users.each { |user| user.reload }
       expect(users[0].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
-      expect(users[0].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[0].topics_with_archived_vote.pluck(:topic_id)).to be_blank
 
       expect(users[1].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
-      expect(users[1].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[1].topics_with_archived_vote.pluck(:topic_id)).to be_blank
 
       expect(users[2].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
-      expect(users[2].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[2].topics_with_archived_vote.pluck(:topic_id)).to be_blank
 
-      expect(users[3].topics_with_vote.pluck(:topic_id)).to contain_exactly()
-      expect(users[3].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[3].topics_with_vote.pluck(:topic_id)).to be_blank
+      expect(users[3].topics_with_archived_vote.pluck(:topic_id)).to be_blank
 
       expect(users[4].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
-      expect(users[4].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[4].topics_with_archived_vote.pluck(:topic_id)).to be_blank
 
       expect(users[5].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
-      expect(users[5].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[5].topics_with_archived_vote.pluck(:topic_id)).to be_blank
 
       expect(topic0.reload.vote_count).to eq(0)
       expect(topic1.reload.vote_count).to eq(5)
@@ -88,14 +88,14 @@ describe DiscourseVoting do
 
       users.each { |user| user.reload }
       expect(users[0].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic0.id)
-      expect(users[0].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[0].topics_with_archived_vote.pluck(:topic_id)).to be_blank
       expect(users[1].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
-      expect(users[1].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[1].topics_with_archived_vote.pluck(:topic_id)).to be_blank
       expect(users[2].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic0.id, topic1.id)
-      expect(users[2].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
-      expect(users[3].topics_with_vote.pluck(:topic_id)).to contain_exactly()
-      expect(users[3].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
-      expect(users[4].topics_with_vote.pluck(:topic_id)).to contain_exactly()
+      expect(users[2].topics_with_archived_vote.pluck(:topic_id)).to be_blank
+      expect(users[3].topics_with_vote.pluck(:topic_id)).to be_blank
+      expect(users[3].topics_with_archived_vote.pluck(:topic_id)).to be_blank
+      expect(users[4].topics_with_vote.pluck(:topic_id)).to be_blank
       expect(users[4].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly(topic0.id)
 
       expect(topic0.reload.vote_count).to eq(4)

--- a/spec/voting_spec.rb
+++ b/spec/voting_spec.rb
@@ -48,7 +48,7 @@ describe DiscourseVoting do
       DiscourseVoting::Vote.create!(user: users[2], topic: topic1)
       DiscourseVoting::Vote.create!(user: users[4], topic: topic0, archive: true)
       DiscourseVoting::Vote.create!(user: users[5], topic: topic0, archive: true)
-      DiscourseVoting::Vote.create!(user: users[5], topic: topic1, archive: true)
+      DiscourseVoting::Vote.create!(user: users[5], topic: topic1)
 
       [topic0, topic1].each { |t| t.update_vote_count }
     end
@@ -59,14 +59,21 @@ describe DiscourseVoting do
       users.each { |user| user.reload }
       expect(users[0].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
       expect(users[0].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+
       expect(users[1].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
       expect(users[1].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+
       expect(users[2].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
       expect(users[2].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+
       expect(users[3].topics_with_vote.pluck(:topic_id)).to contain_exactly()
       expect(users[3].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
-      expect(users[4].topics_with_vote.pluck(:topic_id)).to contain_exactly()
-      expect(users[4].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
+
+      expect(users[4].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
+      expect(users[4].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
+
+      expect(users[5].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic1.id)
+      expect(users[5].topics_with_archived_vote.pluck(:topic_id)).to contain_exactly()
 
       expect(topic0.reload.vote_count).to eq(0)
       expect(topic1.reload.vote_count).to eq(5)


### PR DESCRIPTION
I was able to reproduce a bug where votes were not properly moved when merging two topics together. We were only checking duplicate votes if either both votes were either active or archived, and not a mix of the two. As a result, there were cases where the plugin was trying to move votes that already existed on an open topic, causing the merge to partially fail with a duplicate index error.

What this PR does is as follows:

1. Cleaned up the logic so it's more readable. Previously it was duplicative and difficult to read.
2. We're now checking if a user has a vote on Topic A (active or archived) and Topic B (active or archived) that we're properly deleting the origin vote and keeping the destination vote instead of trying to merge in a duplicate. (This caused the original bug described above).
3. Per the specs [(1)](https://meta.discourse.org/t/plugin-feature-voting-separated-from-likes/38772/) [(2)](https://meta.discourse.org/t/support-merging-of-2-topics-with-voting/58482), topic merges move all votes to the destination topic, and if this causes a user to go over the limit, they'll have to wait until enough votes are released.
4. If the destination topic is closed, the votes will be archived; if the destination topic is open, those votes will be active. This is regardless of origin vote state.

I've ensured tests are passing, but I'm not sure I've covered all cases correctly. Would appreciate a look here.

Also, the Gemfile was missing a source declaration to allow installation of gems/dependencies, so I've added that.