### PR TITLE
FIX: don't send xhr request when vote limit is reached

### DIFF
--- a/assets/javascripts/discourse/widgets/vote-button.js.es6
+++ b/assets/javascripts/discourse/widgets/vote-button.js.es6
@@ -77,7 +77,8 @@ export default createWidget("vote-button", {
     if (
       !this.attrs.closed &&
       this.parentWidget.state.allowClick &&
-      !this.attrs.user_voted
+      !this.attrs.user_voted &&
+      !this.currentUser.votes_exceeded
     ) {
       this.parentWidget.state.allowClick = false;
       this.parentWidget.state.initialVote = true;


### PR DESCRIPTION
When the user used all the votes we should not send a request to create a vote. We should only display information about votes.

The bug was mentioned on meta: https://meta.discourse.org/t/the-vote-button-should-be-disabled-when-the-limit-is-reached/68902

![a7joWJV60j](https://user-images.githubusercontent.com/72780/94496026-a08cbe80-0236-11eb-9c2e-666176dc75b9.gif)
