### PR TITLE
FIX: Ask to log in before requesting who_voted

### DIFF
--- a/assets/javascripts/discourse/widgets/vote-count.js.es6
+++ b/assets/javascripts/discourse/widgets/vote-count.js.es6
@@ -40,6 +40,12 @@ export default createWidget("vote-count", {
   },
 
   click() {
+    if (!this.currentUser) {
+      this.sendWidgetAction("showLogin");
+      $.cookie("destination_url", window.location.href);
+      return;
+    }
+
     if (this.siteSettings.voting_show_who_voted && this.attrs.vote_count > 0) {
       if (this.state.whoVotedUsers === null) {
         return this.getWhoVoted();


### PR DESCRIPTION
`/voting/who` path has `ensure_logged_in` so clicking the vote count to see who voted triggered http requests that ended with 403 error. Now, users are asked to log in, just like when clicking the "vote" button.