### PR TITLE
FIX: the correct path to user profile

### DIFF
--- a/assets/javascripts/discourse/widgets/vote-count.js.es6
+++ b/assets/javascripts/discourse/widgets/vote-count.js.es6
@@ -76,6 +76,6 @@ function whoVotedAvatars(user) {
     template: user.avatar_template,
     username: user.username,
     post_url: user.post_url,
-    url: getURL("/users/") + user.username.toLowerCase(),
+    url: getURL("/u/") + user.username.toLowerCase(),
   };
 }


### PR DESCRIPTION
We should use `/u/:username` instead of `/users/:username`