### PR TITLE
FIX: Always serialize can_vote for first posts

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -44,11 +44,11 @@ after_initialize do
       attributes :can_vote
 
       def include_can_vote?
-        object.post_number == 1 && object.topic && object.topic.can_vote?
+        object.post_number == 1
       end
 
       def can_vote
-        true
+        object.topic&.can_vote?
       end
     end
 

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PostSerializer do
+  let(:user) { Fabricate(:user) }
+  let(:category) { Fabricate(:category) }
+  let(:topic) { Fabricate(:topic, category_id: category.id) }
+
+  before do
+    DiscourseVoting::CategorySetting.create!(category: category)
+    Category.reset_voting_cache
+    SiteSetting.voting_show_who_voted = true
+    SiteSetting.voting_enabled = true
+  end
+
+  it "serializes can_vote for first posts only" do
+    post = Fabricate(:post, topic: topic)
+    json = PostSerializer.new(post, scope: Guardian.new(user), root: false).as_json
+    expect(json[:can_vote]).to eq(true)
+
+    post = Fabricate(:post, topic: topic)
+    json = PostSerializer.new(post, scope: Guardian.new(user), root: false).as_json
+    expect(json[:can_vote]).to eq(nil)
+
+    post = Fabricate(:post)
+    json = PostSerializer.new(post, scope: Guardian.new(user), root: false).as_json
+    expect(json[:can_vote]).to eq(false)
+  end
+end


### PR DESCRIPTION
Changing category settings would not always unhide the like button
because the model would not be updated on the client side until a full
page refresh.