### PR TITLE
DEV: add vote count tag class

### DIFF
--- a/assets/javascripts/discourse/pre-initializers/extend-category-for-voting.js.es6
+++ b/assets/javascripts/discourse/pre-initializers/extend-category-for-voting.js.es6
@@ -23,7 +23,7 @@ function initialize(api) {
 
       let userVotedClass = topic.user_voted ? " voted" : "";
       buffer.push(
-        `<a href='${topic.url}' class='list-vote-count discourse-tag simple${userVotedClass}'${title}>`
+        `<a href='${topic.url}' class='list-vote-count vote-count-${topic.vote_count} discourse-tag simple${userVotedClass}'${title}>`
       );
 
       buffer.push(I18n.t("voting.votes", { count: topic.vote_count }));


### PR DESCRIPTION
This adds a `vote-count-N` class to the vote count tag. This will allow themes to hide a 0 count, and style other counts (e.g., making a topic with many votes stand out more). 