### PR TITLE
FIX: add second order by column to preserve order while paging.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -85,7 +85,7 @@ after_initialize do
           sort_dir = (options[:ascending] == "true") ? "ASC" : "DESC"
           result = result
             .joins("LEFT JOIN discourse_voting_topic_vote_count ON discourse_voting_topic_vote_count.topic_id = topics.id")
-            .reorder("COALESCE(discourse_voting_topic_vote_count.votes_count,'0')::integer #{sort_dir}")
+            .reorder("COALESCE(discourse_voting_topic_vote_count.votes_count,'0')::integer #{sort_dir}, topics.bumped_at DESC")
         end
 
         result

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -23,4 +23,16 @@ describe TopicQuery do
   it "returns topics voted by user" do
     expect(TopicQuery.new(user0, { state: 'my_votes' }).list_latest.topics.map(&:id)).to eq([topic1.id])
   end
+
+  it "orders topic by bumped_at if votes are equal" do
+    topic2 = Fabricate(:topic, category: category1, bumped_at: 2.hours.ago)
+    DiscourseVoting::TopicVoteCount.create!(topic_id: topic2.id, votes_count: 2)
+    topic3 = Fabricate(:topic, category: category1, bumped_at: 3.hours.ago)
+    topic4 = Fabricate(:topic, category: category1, bumped_at: 1.hour.ago)
+
+    opts = { order: 'votes', per_page: 2, category: category1.slug }
+    expect(TopicQuery.new(user0, opts).list_latest.topics.map(&:id)).to eq([topic2.id, topic1.id])
+    expect(TopicQuery.new(user0, opts.merge(page: 1)).list_latest.topics.map(&:id)).to eq([topic0.id, topic4.id])
+    expect(TopicQuery.new(user0, opts.merge(page: 2)).list_latest.topics.map(&:id)).to eq([topic3.id])
+  end
 end


### PR DESCRIPTION
If the number of votes is the same and the second order-by column is not specified then Postgres makes no guarantee about what the ordering will be.

https://meta.discourse.org/t/some-topics-disappear-when-sorting-by-votes/213669