### PR TITLE
FIX: use `t` and `f` instead of boolean values

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.hbs
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.hbs
@@ -2,7 +2,7 @@
 <section class="field">
   <div class="enable-topic-voting">
     <label class="checkbox-label">
-      {{input type="checkbox" click=(action "updateVotingEnabled" value="target.checked")}}
+      {{input type="checkbox" checked=votingEnabled click=(action "updateVotingEnabled" value="target.checked")}}
       {{i18n "voting.allow_topic_voting"}}
     </label>
   </div>

--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.hbs
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.hbs
@@ -2,7 +2,7 @@
 <section class="field">
   <div class="enable-topic-voting">
     <label class="checkbox-label">
-      {{input type="checkbox" checked=category.custom_fields.enable_topic_voting}}
+      {{input type="checkbox" click=(action "updateVotingEnabled" value="target.checked")}}
       {{i18n "voting.allow_topic_voting"}}
     </label>
   </div>

--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.js.es6
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.js.es6
@@ -1,7 +1,7 @@
 export default {
   setupComponent(attrs, component) {
     let votingEnabled = attrs.category?.custom_fields?.discourse_voting_enabled;
-    this.set("votingEnabled", votingEnabled);
+    component.set("votingEnabled", votingEnabled);
   },
   actions: {
     updateVotingEnabled(value) {

--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.js.es6
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.js.es6
@@ -1,4 +1,8 @@
 export default {
+  setupComponent(attrs, component) {
+    let votingEnabled = attrs.category?.custom_fields?.discourse_voting_enabled;
+    this.set("votingEnabled", votingEnabled);
+  },
   actions: {
     updateVotingEnabled(value) {
       this.set(

--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.js.es6
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.js.es6
@@ -1,0 +1,10 @@
+export default {
+  actions: {
+    updateVotingEnabled(value) {
+      this.set(
+        "category.custom_fields.discourse_voting_enabled",
+        value ? "t" : "f"
+      );
+    },
+  },
+};


### PR DESCRIPTION
The controller simply rejects true/false values. We send other boolean values like `auto_populated` as `t` and `f`