### PR TITLE
FIX: handle boolean correctly on server

### DIFF
--- a/lib/discourse_voting/categories_controller_extension.rb
+++ b/lib/discourse_voting/categories_controller_extension.rb
@@ -3,7 +3,7 @@
 module DiscourseVoting
   module CategoriesControllerExtension
     def category_params
-      @vote_enabled ||= params[:custom_fields] && params[:custom_fields].delete(:enable_topic_voting) == "true"
+      @vote_enabled ||= !!ActiveRecord::Type::Boolean.new.cast(params[:custom_fields]&.delete(:enable_topic_voting))
       category_params = super
       if @vote_enabled
         category_params[:category_setting_attributes] = {}

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CategoriesController do
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:admin) { Fabricate(:user, admin: true) }
+
+  before do
+    SiteSetting.voting_enabled = true
+    sign_in(admin)
+  end
+
+  it "enables voting correctly" do
+    put "/categories/#{category.id}.json", params: {
+      custom_fields: { "enable_topic_voting" => true }
+    }
+    expect(Category.can_vote?(category.id)).to eq(true)
+  end
+end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -18,4 +18,11 @@ describe CategoriesController do
     }
     expect(Category.can_vote?(category.id)).to eq(true)
   end
+
+  it "disables voting correctly" do
+    put "/categories/#{category.id}.json", params: {
+      custom_fields: { "enable_topic_voting" => false }
+    }
+    expect(Category.can_vote?(category.id)).to eq(false)
+  end
 end


### PR DESCRIPTION
The voting plugin's category setting is broken per https://meta.discourse.org/t/223880 and https://meta.discourse.org/t/223753

This PR fixes the reported issue.

Earlier the code was checking `params[:custom_fields].delete(:enable_topic_voting) == "true"` which assumes we'll get a `"true"` string but we don't. This value is populated from
https://github.com/discourse/discourse-voting/blob/3d9f4c2996c98cca33380981fbac14bdcc702006/assets/javascripts/discourse/templates/connectors/category-custom-settings/feature-voting-settings.hbs#L5
and the controller converts this to a ruby boolean and hence the condition fails.