### PR TITLE
FIX: do not recreate database record for category setting

### DIFF
--- a/lib/discourse_voting/categories_controller_extension.rb
+++ b/lib/discourse_voting/categories_controller_extension.rb
@@ -5,9 +5,9 @@ module DiscourseVoting
     def category_params
       @vote_enabled ||= !!ActiveRecord::Type::Boolean.new.cast(params[:custom_fields]&.delete(:enable_topic_voting))
       category_params = super
-      if @vote_enabled
+      if @vote_enabled && !@category&.category_setting
         category_params[:category_setting_attributes] = {}
-      elsif @category&.category_setting
+      elsif !@vote_enabled && @category&.category_setting
         category_params[:category_setting_attributes] = { id: @category.category_setting.id, _destroy: '1' }
       end
       category_params

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -19,6 +19,15 @@ describe CategoriesController do
     expect(Category.can_vote?(category.id)).to eq(true)
   end
 
+  it "does not recreate database record" do
+    category_setting = DiscourseVoting::CategorySetting.create!(category: category)
+
+    put "/categories/#{category.id}.json", params: {
+      custom_fields: { "enable_topic_voting" => true }
+    }
+    expect(DiscourseVoting::CategorySetting.last.id).to eq(category_setting.id)
+  end
+
   it "disables voting correctly" do
     put "/categories/#{category.id}.json", params: {
       custom_fields: { "enable_topic_voting" => false }


### PR DESCRIPTION
On the category settings page if the voting plugin is enabled and user
clicks “Save Category” button then the database record for the
`discourse_voting_category_settings` table is deleted and recreated
every time the button is pressed. This commit checks for existing record
and prevents creation of new database record