### PR TITLE
FIX: logs category setting changes when voting is enabled/disabled

### DIFF
--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -7,7 +7,6 @@ describe TopicQuery do
   fab!(:category1) { Fabricate(:category) }
   fab!(:topic0) { Fabricate(:topic, category: category1) }
   fab!(:topic1) { Fabricate(:topic, category: category1) }
-  fab!(:category_setting) { DiscourseVoting::CategorySetting.create!(category_id: category1) }
   fab!(:vote) { DiscourseVoting::Vote.create!(topic_id: topic1.id, user_id: user0.id) }
   fab!(:topic_vote_count) { DiscourseVoting::TopicVoteCount.create!(topic_id: topic1.id, votes_count: 1) }
 

--- a/spec/models/discourse_voting/category_setting_spec.rb
+++ b/spec/models/discourse_voting/category_setting_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe DiscourseVoting::CategorySetting do
+  fab!(:category) { Fabricate(:category) }
+
+  describe 'logs category setting changes' do
+    it "logs changes when voting is enabled/disabled" do
+      DiscourseVoting::CategorySetting.create!(category: category)
+      expect(UserHistory.count).to eq(1)
+
+      DiscourseVoting::CategorySetting.first.destroy!
+      expect(UserHistory.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Since the move to separate tables the category changes to voting plugin was not being logged. This commit fixes that.