### PR TITLE
UX: Avoid double `li` tag in user-activity-bottom outlet

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-activity-bottom/user-voted-topics.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-activity-bottom/user-voted-topics.hbs
@@ -1,7 +1,5 @@
 {{#if siteSettings.voting_show_votes_on_profile}}
-  <li>
-    {{#link-to "userActivity.votes"}}
-      {{d-icon "heart"}} {{i18n "voting.vote_title_plural"}}
-    {{/link-to}}
-  </li>
+  {{#link-to "userActivity.votes"}}
+    {{d-icon "heart"}} {{i18n "voting.vote_title_plural"}}
+  {{/link-to}}
 {{/if}}


### PR DESCRIPTION
The plugin outlet is already wrapped in a `li` tag.

https://github.com/discourse/discourse/blob/c0037dc0f06f08bd050aedc8aad97d1f05b322ab/app/assets/javascripts/discourse/app/templates/user/activity.hbs#L69