### PR TITLE
DEV: Check that setting does not exist before migrate

### DIFF
--- a/db/migrate/20240807020209_rename_incorrect_topic_voting_site_settings.rb
+++ b/db/migrate/20240807020209_rename_incorrect_topic_voting_site_settings.rb
@@ -2,15 +2,59 @@
 
 class RenameIncorrectTopicVotingSiteSettings < ActiveRecord::Migration[7.0]
   def up
-    execute "UPDATE site_settings SET name = 'topic_voting_alert_votes_left' WHERE name = 'voting_alert_votes_left'"
-    execute "UPDATE site_settings SET name = 'topic_voting_enabled' WHERE name = 'voting_enabled'"
-    execute "UPDATE site_settings SET name = 'topic_voting_show_who_voted' WHERE name = 'voting_show_who_voted'"
-    execute "UPDATE site_settings SET name = 'topic_voting_show_votes_on_profile' WHERE name = 'voting_show_votes_on_profile'"
-    execute "UPDATE site_settings SET name = 'topic_voting_tl0_vote_limit' WHERE name = 'voting_tl0_vote_limit'"
-    execute "UPDATE site_settings SET name = 'topic_voting_tl1_vote_limit' WHERE name = 'voting_tl1_vote_limit'"
-    execute "UPDATE site_settings SET name = 'topic_voting_tl2_vote_limit' WHERE name = 'voting_tl2_vote_limit'"
-    execute "UPDATE site_settings SET name = 'topic_voting_tl3_vote_limit' WHERE name = 'voting_tl3_vote_limit'"
-    execute "UPDATE site_settings SET name = 'topic_voting_tl4_vote_limit' WHERE name = 'voting_tl4_vote_limit'"
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_alert_votes_left'
+      WHERE name = 'voting_alert_votes_left' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_alert_votes_left');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_enabled'
+      WHERE name = 'voting_enabled' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_enabled');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_show_who_voted'
+      WHERE name = 'voting_show_who_voted' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_show_who_voted');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_show_votes_on_profile'
+      WHERE name = 'voting_show_votes_on_profile' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_show_votes_on_profile');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_tl0_vote_limit'
+      WHERE name = 'voting_tl0_vote_limit' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_tl0_vote_limit');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_tl1_vote_limit'
+      WHERE name = 'voting_tl1_vote_limit' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_tl1_vote_limit');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_tl2_vote_limit'
+      WHERE name = 'voting_tl2_vote_limit' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_tl2_vote_limit');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_tl3_vote_limit'
+      WHERE name = 'voting_tl3_vote_limit' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_tl3_vote_limit');
+    SQL
+
+    execute <<-SQL
+      UPDATE site_settings SET name = 'topic_voting_tl4_vote_limit'
+      WHERE name = 'voting_tl4_vote_limit' AND
+        NOT EXISTS (SELECT 1 FROM site_settings WHERE name = 'topic_voting_tl4_vote_limit');
+    SQL
   end
 
   def down


### PR DESCRIPTION
Fix for - https://github.com/discourse/discourse-topic-voting/pull/202. That PR was a fix for a failed rename, but did not check if the setting may have already been overwritten manually by admins.

1. if the problematic migration already ran, it will result in the plugin being disabled if it was already enabled.
2. admins enable it manually
3. the new "correcting" migration in https://github.com/discourse/discourse-topic-voting/pull/202 would fail because the record already exists.