### PR TITLE
FIX: Care for nil counts when ordering

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -121,7 +121,9 @@ after_initialize do
 
   filter_order_votes = ->(scope, order_direction) do
     scope = scope.joins(:topic_vote_count)
-    scope.order("topic_voting_topic_vote_count.votes_count #{order_direction}")
+    scope.order(
+      "COALESCE(topic_voting_topic_vote_count.votes_count, 0)::integer #{order_direction}",
+    )
   end
 
   add_filter_custom_filter("order:votes", &filter_order_votes)

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe TopicsFilter do
   describe "adding order:votes to DiscoursePluginRegistry.custom_filter_mappings" do
     fab!(:topic_high) { Fabricate(:topic_voting_vote_count, votes_count: 10).topic }
     fab!(:topic_med) { Fabricate(:topic_voting_vote_count, votes_count: 5).topic }
-    fab!(:topic_low) { Fabricate(:topic_voting_vote_count, votes_count: 1).topic }
+    fab!(:topic_low) { Fabricate(:topic_voting_vote_count, votes_count: 0).topic }
+    fab!(:topic_nil) { Fabricate(:topic_voting_vote_count, votes_count: nil).topic }
 
     it "sorts votes in ascending order" do
       expect(
@@ -12,13 +13,13 @@ RSpec.describe TopicsFilter do
           .new(guardian: Guardian.new)
           .filter_from_query_string("order:votes-asc")
           .pluck(:id),
-      ).to eq([topic_low.id, topic_med.id, topic_high.id])
+      ).to eq([topic_low.id, topic_nil.id, topic_med.id, topic_high.id])
     end
 
     it "sorts votes in default descending order" do
       expect(
         TopicsFilter.new(guardian: Guardian.new).filter_from_query_string("order:votes").pluck(:id),
-      ).to eq([topic_high.id, topic_med.id, topic_low.id])
+      ).to eq([topic_high.id, topic_med.id, topic_low.id, topic_nil.id])
     end
   end
 end


### PR DESCRIPTION
In https://github.com/discourse/discourse-topic-voting/pull/204 we allowed for https://meta.discourse.org/filter?q=order%3Avotes, but did not coalesce nils to zeroes. This resulted in nils being above higher voted topics.

This PR makes sure the order is correct when nils are included.