### PR TITLE
DEV: Drop old tables that have been renamed

### DIFF
--- a/db/migrate/20241203125415_rename_reassign_sequences.rb
+++ b/db/migrate/20241203125415_rename_reassign_sequences.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RenameReassignSequences < ActiveRecord::Migration[7.0]
+  def up
+    reassign_sequence("discourse_voting_topic_vote_count_id_seq", "topic_voting_topic_vote_count")
+    reassign_sequence("discourse_voting_votes_id_seq", "topic_voting_votes")
+    reassign_sequence("discourse_voting_category_settings_id_seq", "topic_voting_category_settings")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def reassign_sequence(sequence_name, new_table_name)
+    execute <<~SQL
+      ALTER SEQUENCE #{sequence_name}
+      OWNED BY #{new_table_name}.id;
+    SQL
+  end
+end

--- a/db/post_migrate/20241203125523_drop_old_discourse_voting_tables.rb
+++ b/db/post_migrate/20241203125523_drop_old_discourse_voting_tables.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropOldDiscourseVotingTables < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :discourse_voting_topic_vote_count, if_exists: true
+    drop_table :discourse_voting_votes, if_exists: true
+    drop_table :discourse_voting_category_settings, if_exists: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The PR to rename the tables has been around for quite a while (5mo) - https://github.com/discourse/discourse-topic-voting/pull/196 - and it is now safe to drop the old table.

The new tables are prefixed with `topic-voting-`, the old tables are `discourse-voting-`.

This PR also transfers the sequences to the new tables.