### PR TITLE
DEV: Also rename sequences away from discourse_voting prefix

### DIFF
--- a/db/migrate/20241210081242_rename_sequences.rb
+++ b/db/migrate/20241210081242_rename_sequences.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class RenameSequences < ActiveRecord::Migration[7.0]
+  def up
+    rename_sequence(
+      "discourse_voting_topic_vote_count_id_seq",
+      "topic_voting_topic_vote_count_id_seq",
+    )
+    rename_sequence("discourse_voting_votes_id_seq", "topic_voting_votes_id_seq")
+    rename_sequence(
+      "discourse_voting_category_settings_id_seq",
+      "topic_voting_category_settings_id_seq",
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def rename_sequence(existing_sequence_name, new_name)
+    execute <<~SQL
+      ALTER SEQUENCE #{existing_sequence_name}
+      RENAME TO #{new_name};
+    SQL
+  end
+end


### PR DESCRIPTION
A follow up from https://github.com/discourse/discourse-topic-voting/commit/6d52b8cfa8b3e2920aa3f12fc52673b88f53f776, sequences were reassigned but not renamed.